### PR TITLE
Improve scoping of ingredient amounts

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -1,0 +1,31 @@
+name: Syntax Tests
+
+on:
+  push:
+    paths:
+      - '.github/workflows/syntax.yml'
+      - '**.sublime-syntax'
+      - '**/syntax_test_*'
+      - '**.tmPreferences'
+  pull_request:
+    paths:
+      - '.github/workflows/syntax.yml'
+      - '**.sublime-syntax'
+      - '**/syntax_test_*'
+      - '**.tmPreferences'
+
+jobs:
+  main:
+    name: Syntax Tests (${{ matrix.build }})
+    strategy:
+      matrix:
+        include:
+          - build: 4094
+            packages: master
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: SublimeText/syntax-test-action@v2
+        with:
+          build: ${{ matrix.build }}
+          default_packages: ${{ matrix.packages }}

--- a/CookLang/Cook.sublime-syntax
+++ b/CookLang/Cook.sublime-syntax
@@ -50,11 +50,17 @@ contexts:
                   pop: true
                 - match: (?=\S)
                   set:
-                    - meta_include_prototype: false
-                    - meta_scope: metadata.cook
-                    - match: .+$\n?
-                      scope: value.metadata.cook string.unquoted.plain.out.cook
+                    - metadata_value_ingredient
+                  with_prototype:
+                    - match: $\n?
                       pop: true
+
+  metadata_value_ingredient:
+    - meta_include_prototype: false
+    - meta_scope: value.metadata.cook
+    - match: $\n?
+      pop: true
+    - include: ingredient_amount_quantity
 
   step:
 
@@ -94,12 +100,12 @@ contexts:
     - match: (?<=@)(\w+?)(?={)
       scope: entity.name.tag.ingredient.one-word.cook
       push:
-        - ingredient_amount
+        - begin_ingredient_amount
 
     - match: (?<=@)([^{{special_symbols}}]+?)(?={)
       scope: entity.name.tag.ingredient.multi-word.cook
       push:
-        - ingredient_amount
+        - begin_ingredient_amount
 
     - match: (?<=@)(.+?)\b
       scope: entity.name.tag.ingredient.one-word.cook
@@ -108,27 +114,42 @@ contexts:
     - match: ''
       pop: true
 
-  ingredient_amount:
+  amount_number:
+    - match: \d+
+      scope: meta.number.integer.decimal.cook constant.numeric.value.cook
+
+  begin_ingredient_amount:
     - match: \{
       scope: punctuation.definition.ingredient.amount.begin.cook
       set:
+        - ingredient_amount_quantity
 
-        - match: \}
-          scope: punctuation.definition.ingredient.amount.end.cook
-          pop: true
+  inside_ingredient_amount:
+    - match: \}
+      scope: punctuation.definition.ingredient.amount.end.cook
+      pop: true
+    - match: $\n?
+      scope: invalid.illegal.expected-end-of-amount.cook
+      pop: true
 
-        - match: '[^}%]+?(?=}|%)'
-          scope: constant.string.ingredient.amount.cook
+  ingredient_amount_quantity:
+    - include: inside_ingredient_amount
+    - include: amount_number
+    - match: \%
+      scope: punctuation.definition.ingredient.amount.separator.cook
+      set: ingredient_amount_after_quantity
+    - match: \|
+      scope: punctuation.separator.sequence.cook
+    - match: '[/*]'
+      scope: keyword.operator.arithmetic.cook
 
-        - match: \%
-          scope: punctuation.definition.ingredient.amount.separator.cook
+  ingredient_amount_after_quantity:
+    - include: inside_ingredient_amount
+    - match: '[^}%]+?(?=}|%)'
+      scope: constant.string.ingredient.amount.cook
 
-        - match: '[^}%]+?(?=$\n)'
-          scope: constant.string.ingredient.amount.cook
-
-        - match: $\n?
-          scope: invalid.illegal.expected-end-of-amount.cook
-          pop: true
+    - match: '[^}%]+?(?=$\n)'
+      scope: constant.string.ingredient.amount.cook
 
   equipment:
     - match: (?<=#)(\w+?)(?={)
@@ -184,6 +205,7 @@ contexts:
           scope: punctuation.definition.timer.duration.end.cook
           pop: true
 
+        - include: amount_number
         - match: '[^}%]+?(?=}|%)'
           scope: constant.string.timer.duration.cook
 
@@ -199,14 +221,17 @@ contexts:
 
 
   comments:
-    - match: (--).*$\n?
-      scope: comment.line.double-dash.cook
-      captures:
-        1: punctuation.definition.comment.cook
+    - match: '--'
+      scope: punctuation.definition.comment.cook
+      push:
+        - meta_scope: comment.line.double-dash.cook
+        - match: $\n?
+          pop: true
 
     - match: '\[\-'
-      scope: punctuation.definition.comment.c
+      scope: punctuation.definition.comment.begin.cook
       push:
-        - meta_scope: comment.block.c
+        - meta_scope: comment.block.cook
         - match: '\-\]'
+          scope: punctuation.definition.comment.end.cook
           pop: true

--- a/CookLang/syntax_test_comment.cook
+++ b/CookLang/syntax_test_comment.cook
@@ -5,4 +5,7 @@
 -- ^^^^^^^^^^^^^^^^^^^^ comment.line.double-dash.cook
 
 Mash @potato{2%kg} until smooth -- alternatively, boil 'em first, then mash 'em, then stick 'em in a stew.
---                              ^^^^^^^^^^^^^^^^^^^^ comment.line.double-dash.cook
+--                              ^^ punctuation.definition.comment
+--                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-dash.cook
+
+-- <- - comment

--- a/CookLang/syntax_test_comment.cook
+++ b/CookLang/syntax_test_comment.cook
@@ -1,4 +1,4 @@
--- SYNTAX TEST "Packages/CookLang/Cook.sublime-syntax"
+-- SYNTAX TEST "Packages/CookLang/CookLang/Cook.sublime-syntax"
 
 -- Don't burn the roux!
 -- <- comment.line.double-dash.cook

--- a/CookLang/syntax_test_comment.cook
+++ b/CookLang/syntax_test_comment.cook
@@ -1,4 +1,4 @@
--- SYNTAX TEST "Packages/CookLang/CookLang/Cook.sublime-syntax"
+-- SYNTAX TEST "Cook.sublime-syntax"
 
 -- Don't burn the roux!
 -- <- comment.line.double-dash.cook

--- a/CookLang/syntax_test_equipment.cook
+++ b/CookLang/syntax_test_equipment.cook
@@ -1,4 +1,4 @@
--- SYNTAX TEST "Packages/CookLang/Cook.sublime-syntax"
+-- SYNTAX TEST "Packages/CookLang/CookLang/Cook.sublime-syntax"
 
 Place the potatoes into a #pot.
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.cook

--- a/CookLang/syntax_test_equipment.cook
+++ b/CookLang/syntax_test_equipment.cook
@@ -1,4 +1,4 @@
--- SYNTAX TEST "Packages/CookLang/CookLang/Cook.sublime-syntax"
+-- SYNTAX TEST "Cook.sublime-syntax"
 
 Place the potatoes into a #pot.
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.cook

--- a/CookLang/syntax_test_ingredient.cook
+++ b/CookLang/syntax_test_ingredient.cook
@@ -13,16 +13,16 @@ Poke holes in @potato{2}.
 --            ^ punctuation.definition.ingredient.cook
 --             ^^^^^^ entity.name.tag.ingredient.one-word.cook
 --                   ^ punctuation.definition.ingredient.amount.begin.cook
---                    ^ constant.string.ingredient.amount.cook
+--                    ^ meta.number.integer.decimal.cook constant.numeric.value.cook
 --                     ^ punctuation.definition.ingredient.amount.end.cook
 
 Place @bacon strips{1%kg} about 70-80 g each on a #baking sheet{} and glaze with @syrup{1/2%tbsp}.
 --    ^ punctuation.definition.ingredient.cook
 --     ^^^^^^^^^^^^ entity.name.tag.ingredient.multi-word.cook
 --                 ^ punctuation.definition.ingredient.amount.begin.cook
---                  ^ constant.string.ingredient.amount.cook
+--                  ^ meta.number.integer.decimal.cook constant.numeric.value.cook
 --                   ^ punctuation.definition.ingredient.amount.separator.cook
---                    ^ constant.string.ingredient.amount.cook
+--                    ^^ constant.string.ingredient.amount.cook
 --                      ^ punctuation.definition.ingredient.amount.end.cook
 
 Mix in bacon, @shredded cheddar cheese{1/5*%cup}, and @sour cream{1/6*%cup}. Then add @salt, and @pepper to taste.
@@ -31,7 +31,7 @@ Top with @green onions{1%tbsp}(finely chopped).
 --       ^ punctuation.definition.ingredient.cook
 --        ^^^^^^^^^^^^ entity.name.tag.ingredient.multi-word.cook
 --                    ^ punctuation.definition.ingredient.amount.begin.cook
---                     ^ constant.string.ingredient.amount.cook
+--                     ^ meta.number.integer.decimal.cook constant.numeric.value.cook
 --                      ^ punctuation.definition.ingredient.amount.separator.cook
 --                       ^^^^ constant.string.ingredient.amount.cook
 --                           ^ punctuation.definition.ingredient.amount.end.cook
@@ -43,7 +43,10 @@ Add @milk{1/2*%cup} and mix until smooth.
 --  ^ punctuation.definition.ingredient.cook
 --   ^^^^ entity.name.tag.ingredient.one-word.cook
 --       ^ punctuation.definition.ingredient.amount.begin.cook
---        ^^^^ constant.string.ingredient.amount.cook
+--        ^ meta.number.integer.decimal constant.numeric.value
+--         ^ keyword.operator.arithmetic
+--          ^ meta.number.integer.decimal constant.numeric.value
+--           ^ keyword.operator.arithmetic
 --            ^ punctuation.definition.ingredient.amount.separator.cook
 --             ^^^ constant.string.ingredient.amount.cook
 --                ^ punctuation.definition.ingredient.amount.end.cook
@@ -52,7 +55,11 @@ Add @salt{1|1|1%tsp}
 --  ^ punctuation.definition.ingredient.cook
 --   ^^^^ entity.name.tag.ingredient.one-word.cook
 --       ^ punctuation.definition.ingredient.amount.begin.cook
---        ^^^^^ constant.string.ingredient.amount.cook
+--        ^ meta.number.integer.decimal constant.numeric.value
+--         ^ punctuation.separator.sequence
+--          ^ meta.number.integer.decimal constant.numeric.value
+--           ^ punctuation.separator.sequence
+--            ^ meta.number.integer.decimal constant.numeric.value
 --             ^ punctuation.definition.ingredient.amount.separator.cook
 --              ^^^ constant.string.ingredient.amount.cook
 --                 ^ punctuation.definition.ingredient.amount.end.cook
@@ -65,7 +72,7 @@ Poke holes in @potato{2%lar
 --            ^ punctuation.definition.ingredient.cook
 --             ^^^^^^ entity.name.tag.ingredient.one-word.cook
 --                   ^ punctuation.definition.ingredient.amount.begin.cook
---                    ^ constant.string.ingredient.amount.cook
+--                    ^ meta.number.integer.decimal.cook constant.numeric.value.cook
 --                     ^ punctuation.definition.ingredient.amount.separator.cook
 --                      ^^^ constant.string.ingredient.amount.cook
 --                         ^ invalid.illegal.expected-end-of-amount.cook
@@ -74,7 +81,7 @@ Top with @green onions{1%tbsp}(finely cho
 --       ^ punctuation.definition.ingredient.cook
 --        ^^^^^^^^^^^^ entity.name.tag.ingredient.multi-word.cook
 --                    ^ punctuation.definition.ingredient.amount.begin.cook
---                     ^ constant.string.ingredient.amount.cook
+--                     ^ meta.number.integer.decimal.cook constant.numeric.value.cook
 --                      ^ punctuation.definition.ingredient.amount.separator.cook
 --                       ^^^^ constant.string.ingredient.amount.cook
 --                           ^ punctuation.definition.ingredient.amount.end.cook

--- a/CookLang/syntax_test_ingredient.cook
+++ b/CookLang/syntax_test_ingredient.cook
@@ -1,4 +1,4 @@
--- SYNTAX TEST "Packages/CookLang/Cook.sublime-syntax"
+-- SYNTAX TEST "Packages/CookLang/CookLang/Cook.sublime-syntax"
 
 Then add @salt and @ground black pepper{} to taste.
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.cook

--- a/CookLang/syntax_test_ingredient.cook
+++ b/CookLang/syntax_test_ingredient.cook
@@ -1,4 +1,4 @@
--- SYNTAX TEST "Packages/CookLang/CookLang/Cook.sublime-syntax"
+-- SYNTAX TEST "Cook.sublime-syntax"
 
 Then add @salt and @ground black pepper{} to taste.
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.cook

--- a/CookLang/syntax_test_metadata.cook
+++ b/CookLang/syntax_test_metadata.cook
@@ -1,4 +1,4 @@
--- SYNTAX TEST "Packages/CookLang/CookLang/Cook.sublime-syntax"
+-- SYNTAX TEST "Cook.sublime-syntax"
 
 >> source: https://www.gimmesomeoven.com/baked-potato/
 -- ^^^^^^^^^^^^^ text.cook

--- a/CookLang/syntax_test_metadata.cook
+++ b/CookLang/syntax_test_metadata.cook
@@ -27,3 +27,15 @@
 -- ^^^^^^^ entity.name.tag.metadata.cook
 --          ^^^^^^^ value.metadata.cook
 --        ^ punctuation.separator.mapping.key-value.cook
+
+>> servings: 1
+>> produce: 350%g
+--          ^^^ meta.number.integer.decimal constant.numeric.value
+--             ^ punctuation.definition.ingredient.amount.separator
+--              ^ constant.string.ingredient.amount
+--               ^ - invalid
+>> calories: 670%kkal
+-- <- metadata punctuation.section.mapping.begin
+>> protein: 40%g
+>> total fat: 50%g
+>> total carb.: 11%g

--- a/CookLang/syntax_test_metadata.cook
+++ b/CookLang/syntax_test_metadata.cook
@@ -1,4 +1,4 @@
--- SYNTAX TEST "Packages/CookLang/Cook.sublime-syntax"
+-- SYNTAX TEST "Packages/CookLang/CookLang/Cook.sublime-syntax"
 
 >> source: https://www.gimmesomeoven.com/baked-potato/
 -- ^^^^^^^^^^^^^ text.cook

--- a/CookLang/syntax_test_timer.cook
+++ b/CookLang/syntax_test_timer.cook
@@ -1,4 +1,4 @@
--- SYNTAX TEST "Packages/CookLang/Cook.sublime-syntax"
+-- SYNTAX TEST "Packages/CookLang/CookLang/Cook.sublime-syntax"
 
 Lay the potatoes on a #baking sheet{} and place into the #oven{}. Bake for ~{25%minutes}.
 --                                                                         ^ punctuation.definition.timer.cook

--- a/CookLang/syntax_test_timer.cook
+++ b/CookLang/syntax_test_timer.cook
@@ -3,7 +3,7 @@
 Lay the potatoes on a #baking sheet{} and place into the #oven{}. Bake for ~{25%minutes}.
 --                                                                         ^ punctuation.definition.timer.cook
 --                                                                          ^ punctuation.definition.timer.duration.begin.cook
---                                                                           ^^ constant.string.timer.duration.cook
+--                                                                           ^^ meta.number.integer.decimal constant.numeric.value
 --                                                                             ^ punctuation.definition.timer.duration.separator.cook
 --                                                                              ^^^^^^^ constant.string.timer.duration.cook
 --                                                                                     ^ punctuation.definition.timer.duration.end.cook
@@ -18,14 +18,14 @@ Cook for ~eggs{4%min} and ~bacon strips{7%min}.
 --       ^ punctuation.definition.timer.cook
 --        ^^^^ entity.name.tag.timer.one-word.cook
 --            ^ punctuation.definition.timer.duration.begin.cook
---             ^ constant.string.timer.duration.cook
+--             ^ meta.number.integer.decimal constant.numeric.value
 --              ^ punctuation.definition.timer.duration.separator.cook
 --               ^^^ constant.string.timer.duration.cook
 --                  ^ punctuation.definition.timer.duration.end.cook
 --                        ^ punctuation.definition.timer.cook
 --                         ^^^^ entity.name.tag.timer.multi-word.cook
 --                                     ^ punctuation.definition.timer.duration.begin.cook
---                                      ^ constant.string.timer.duration.cook
+--                                      ^ meta.number.integer.decimal constant.numeric.value
 --                                       ^ punctuation.definition.timer.duration.separator.cook
 --                                        ^^^ constant.string.timer.duration.cook
 --                                           ^ punctuation.definition.timer.duration.end.cook

--- a/CookLang/syntax_test_timer.cook
+++ b/CookLang/syntax_test_timer.cook
@@ -1,4 +1,4 @@
--- SYNTAX TEST "Packages/CookLang/CookLang/Cook.sublime-syntax"
+-- SYNTAX TEST "Cook.sublime-syntax"
 
 Lay the potatoes on a #baking sheet{} and place into the #oven{}. Bake for ~{25%minutes}.
 --                                                                         ^ punctuation.definition.timer.cook


### PR DESCRIPTION
- fix the syntax tests by ensuring they reference the correct path to the syntax definition.
- add a GitHub Action to run the syntax tests on PRs to verify correctness
- improve scoping of ingredient amounts
  - scope numbers
  - scope serving separator
  - scope operators like the slash for fractions and the `*` used for scaling i.e. `@milk{1/2*%cup}`
  - including in metadata